### PR TITLE
Fix postgres version

### DIFF
--- a/vagrant/postgresql/app/start.sh
+++ b/vagrant/postgresql/app/start.sh
@@ -3,8 +3,8 @@ echo '===== Creating PostgreSQL databases and users ====='
 su postgres
 
 # Update pg_hba.conf to trust local peer connection
-sed -i  '/^local   all             all                                     peer/ s/peer/trust/' /etc/postgresql/12/main/pg_hba.conf
-cat /etc/postgresql/12/main/pg_hba.conf
+sed -i  '/^local   all             all                                     peer/ s/peer/trust/' /etc/postgresql/13/main/pg_hba.conf
+cat /etc/postgresql/13/main/pg_hba.conf
 
 # Restart Postgres to udpate conf
 /etc/init.d/postgresql restart


### PR DESCRIPTION
## PR Details

This PR fixes filename of postgresql from 12 to 13

### Description

In universal mode, `vagrant up` fails with "file not found" error when trying to create "postgresql". I suggest it's due to postgresql's version up from 12 to 13.
This PR fixes this bug.

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

### Full changelog

<!--- What changes does your code introduce? -->

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #92
