### PR TITLE
Version up KUMA_VERSION from 0.7.1 to 0.7.2

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -147,17 +147,17 @@ $ curl -L https://kuma.io/installer.sh | sh -
 
 INFO	Welcome to the Kuma automated download!
 INFO	Fetching latest Kuma version..
-INFO	Kuma version: 0.7.1
+INFO	Kuma version: 0.7.2
 INFO	Kuma architecture: amd64
 INFO	Operating system: darwin
-INFO	Downloading Kuma from: https://kong.bintray.com/kuma/kuma-0.7.1-darwin-amd64.tar.gz
+INFO	Downloading Kuma from: https://kong.bintray.com/kuma/kuma-0.7.2-darwin-amd64.tar.gz
 
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
 100 49.8M  100 49.8M    0     0  11.1M      0  0:00:04  0:00:04 --:--:-- 14.7M
 
-INFO	Kuma 0.7.1 has been downloaded!
+INFO	Kuma 0.7.2 has been downloaded!
 
 Welcome to Kuma!
 
@@ -210,10 +210,10 @@ running in your system:
 * https://kuma.io/policies/
 ```
 
-Next, navigate into the `kuma-0.7.1/bin` directory where the kuma components will be:
+Next, navigate into the `kuma-0.7.2/bin` directory where the kuma components will be:
 
 ```bash
-$ cd kuma-0.7.1/bin && ls
+$ cd kuma-0.7.2/bin && ls
 envoy              kuma-dp            kumactl
 kuma-cp            kuma-prometheus-sd
 ```

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -106,17 +106,17 @@ $ curl -L https://kuma.io/installer.sh | sh -
 
 INFO	Welcome to the Kuma automated download!
 INFO	Fetching latest Kuma version..
-INFO	Kuma version: 0.7.1
+INFO	Kuma version: 0.7.2
 INFO	Kuma architecture: amd64
 INFO	Operating system: darwin
-INFO	Downloading Kuma from: https://kong.bintray.com/kuma/kuma-0.7.1-darwin-amd64.tar.gz
+INFO	Downloading Kuma from: https://kong.bintray.com/kuma/kuma-0.7.2-darwin-amd64.tar.gz
 
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
 100 49.8M  100 49.8M    0     0  11.1M      0  0:00:04  0:00:04 --:--:-- 14.7M
 
-INFO	Kuma 0.7.1 has been downloaded!
+INFO	Kuma 0.7.2 has been downloaded!
 
 Welcome to Kuma!
 
@@ -169,10 +169,10 @@ running in your system:
 * https://kuma.io/policies/
 ```
 
-Next, navigate into the `kuma-0.7.1/bin` directory where the kuma components will be:
+Next, navigate into the `kuma-0.7.2/bin` directory where the kuma components will be:
 
 ```bash
-$ cd kuma-0.7.1/bin && ls
+$ cd kuma-0.7.2/bin && ls
 envoy              kuma-dp            kumactl
 kuma-cp            kuma-prometheus-sd
 ```

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-KUMA_VERSION = "0.7.1"
+KUMA_VERSION = "0.7.2"
 KUMA_HOME    = "/opt/kuma"
 
 KUMA_CONTROL_PLANE_IP      = "192.168.33.10"


### PR DESCRIPTION
Signed-off-by: Yuiko Mori <yuiko-mori@nec.com>

## PR Details

This PR fixes kuma version  to 0.7.2 in:

- vagrant/Vagrantfile
- vagrant/README.md
- kubernetes/README.md


