### PR TITLE
Fix failing vagrant provisioning

### DIFF
--- a/vagrant/common/download_kuma.sh
+++ b/vagrant/common/download_kuma.sh
@@ -19,8 +19,8 @@ export KUMA_VERSION=kuma-${KUMA_VERSION}
 export PATH=\$PATH:\$KUMA_HOME/bin
 " > /etc/profile.d/kuma.sh
 
-# Download latest version of Kuma for the detected OS, please check out https://kuma.io/install for more options
-curl --silent https://kuma.io/installer.sh | sh >/dev/null 2>&1
+# Download specified version of Kuma for the detected OS, please check out https://kuma.io/install for more options
+curl --silent https://kuma.io/installer.sh | VERSION=$KUMA_VERSION sh >/dev/null 2>&1
 
 # Move to KUMA_HOME directory 
 mv kuma-${KUMA_VERSION} ${KUMA_HOME}


### PR DESCRIPTION
Signed-off-by: Jacek Ewertowski <jacek.ewertowski1@gmail.com>

## PR Details

I was trying to run kuma demo in vagrant and provisioning failed while starting vm `kuma-control-plane` with error:
```
kuma-control-plane: mv: 
kuma-control-plane: cannot stat 'kuma-0.7.1'
kuma-control-plane: : No such file or directory
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```
The cause of the problem is that the script `download_kuma.sh` executes the installer without arguments and therefore installer downloads the latest version of Kuma. For now the latest version is `1.0.0` and the env variable `$KUMA_VERSION` is set to `0.7.1`, therefore when the vagrant moves `kuma-0.7.1` to `$KUMA_HOME` the process fails, because the directory does not exist.

### Full changelog

* Pass kuma version to script `installer.sh`