### PR TITLE
fix: kong cannot start successfully

### DIFF
--- a/vagrant/kong/app/install.sh
+++ b/vagrant/kong/app/install.sh
@@ -15,8 +15,6 @@ EOF
 
 apt-get update -y -q
 apt-get install -y -q apt-transport-https curl lsb-core
-echo "deb https://kong.bintray.com/kong-deb `lsb_release -sc` main" | sudo tee -a /etc/apt/sources.list
-curl -o bintray.key https://bintray.com/user/downloadSubjectPublicKey?username=bintray
-apt-key add bintray.key
+echo "deb [trusted=yes] https://download.konghq.com/gateway-2.x-ubuntu-$(lsb_release -sc)/ default all" | sudo tee /etc/apt/sources.list.d/kong.list 
 apt-get update -y -q
 apt-get install -y -q kong


### PR DESCRIPTION
## PR Details

kong cannot start successfully

### Description

` kong: deb https://kong.bintray.com/kong-deb bionic main
    kong:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    kong:                                  Dload  Upload   Total   Spent    Left  Speed
100   162  100   162    0     0    130      0  0:00:01  0:00:01 --:--:--   130
    kong: Warning: apt-key output should not be parsed (stdout is not a terminal)
    kong: gpg: no valid OpenPGP data found.
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.`

### Motivation and Context

Update kong installs by following the introduction at https://docs.konghq.com/install/ubuntu/ to install kong successfully.
