### PR TITLE
Postgres path isn`t same

### DIFF
--- a/vagrant/postgresql/app/start.sh
+++ b/vagrant/postgresql/app/start.sh
@@ -3,8 +3,8 @@ echo '===== Creating PostgreSQL databases and users ====='
 su postgres
 
 # Update pg_hba.conf to trust local peer connection
-sed -i  '/^local   all             all                                     peer/ s/peer/trust/' /etc/postgresql/13/main/pg_hba.conf
-cat /etc/postgresql/13/main/pg_hba.conf
+sed -i  '/^local   all             all                                     peer/ s/peer/trust/' /etc/postgresql/*/main/pg_hba.conf
+cat /etc/postgresql/*/main/pg_hba.conf
 
 # Restart Postgres to udpate conf
 /etc/init.d/postgresql restart


### PR DESCRIPTION
The number fixed in postgres path, gets errors in my vagrant, for fix it, i just change the path from 13 to 14. maybe could be a good idea use an * in it to prevent it occours