### PR TITLE
mount a volume into postgre container to support run postgre db by a non-root user

### DIFF
--- a/kubernetes/kuma-demo-aio.yaml
+++ b/kubernetes/kuma-demo-aio.yaml
@@ -33,6 +33,8 @@ spec:
           value: kumademo
         - name: POSTGRES_DB
           value: kumademo
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
         resources:
           requests:
             cpu: 100m
@@ -42,6 +44,12 @@ spec:
             memory: 256Mi
         ports:
         - containerPort: 5432
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: pgdata
+      volumes:
+      - emptyDir: {}
+        name: pgdata
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
On OpenShift clusters, containers will be assigned to an arbitrary user ID within the range of [1000670000, 1000679999], and they don't have permission to write  `/var/run/postgresql` which is the default data directory of the database image.

This PR is to fix the issue above by mounting a volume into the container and let the db put data into a subdirectory, so that it will be writable.

```
chmod: /var/run/postgresql: Operation not permitted
```

<Explain your change!>

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)
- Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
- Yes
